### PR TITLE
Initial implementation

### DIFF
--- a/.github/workflows/docker-publisher.yaml
+++ b/.github/workflows/docker-publisher.yaml
@@ -1,0 +1,40 @@
+name: Publish Docker image
+
+on:
+  # weekly builds for security updates
+  schedule:
+    - cron: "0 18 * * 3"
+  # and rebuild whenever we change this repo
+  push:
+    branches: [main]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/reddit/bazelisk:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM golang:1 AS builder
+
+RUN mkdir -p /tmp/gopath/
+
+ENV GOPATH /tmp/gopath/
+
+RUN go install github.com/bazelbuild/bazelisk@latest
+
+FROM ubuntu:bionic
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+  apt-get install -y \
+  git \
+  python \
+  python-pip \
+  python3 \
+  python3-pip \
+  curl \
+  build-essential \
+  g++ \
+  zip \
+  unzip \
+  openjdk-11-jdk-headless \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/
+
+RUN mkdir -p /usr/local/bin
+
+COPY --from=builder /tmp/gopath/bin/bazelisk /usr/local/bin/bazelisk
+
+RUN ln -s /usr/local/bin/bazelisk /usr/local/bin/bazel
+
+# This both verifies that bazel is in $PATH,
+# and also caches the latest bazel release at the time of docker build.
+RUN bazel version
+
+RUN mkdir -p /opt
+
+WORKDIR /opt/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2021, reddit
+Copyright (c) 2021 Reddit Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # docker-bazelisk
-Docker image for Bazelisk
+
+Docker image for [Bazelisk].
+
+[Bazelisk]: https://github.com/bazelbuild/bazelisk


### PR DESCRIPTION
We currently use Google's official Bazel docker image in Baseplate.go,
but that image stopped updating after 3.5.0[1], and some of the rules
dropped support for Bazel pre-4.0.0, so build a Bazelisk based bazel
image instead.

This image will be auto refreshed weekly.

[1]: https://groups.google.com/g/bazel-discuss/c/z6NmBAE4yF8/